### PR TITLE
Updated references to old Docker image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This will increase chralps and fagges "burrito" - points by 2 ( each )
 2. Set environment variables that you need / want. Check "Environment variables" for more details.
 3. `docker-compose up -d`.
 
-( Dockerhub repo => https://hub.docker.com/r/chralp/heyburrito  )
+( Dockerhub repo => https://hub.docker.com/r/jrewerts/heyburrito  )
 ### Node
 1. `git clone git@github.com:chralp/heyburrito.git`
 2. `cd heyburrito`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "27017:27017"
   heyburrito:
-    image: chralp/heyburrito:latest
+    image: jrewerts/heyburrito:latest
     ports:
       - "3333:3333"
       - "8080:8080"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "mocha -r ts-node/register test/* || true",
     "lint": "tslint -t stylish -c tslint.json lib/*.ts types/*.ts test/*.ts",
     "lintFix": "tslint -t stylish -c tslint.json lib/*.ts types/*.ts test/*.ts --fix",
-    "docker-build": "docker build -t chralp/heyburrito . && docker tag chralp/heyburrito chralp/heyburrito",
-    "docker-push": "docker push chralp/heyburrito"
+    "docker-build": "docker build -t jrewerts/heyburrito . && docker tag jrewerts/heyburrito jrewerts/heyburrito",
+    "docker-push": "docker push jrewerts/heyburrito"
   },
   "dependencies": {
     "@slack/client": "^4.12.0",


### PR DESCRIPTION
I've pushed a new version of our Docker image [here](https://cloud.docker.com/u/jrewerts/repository/docker/jrewerts/heyburrito). Let me know if we need this in a DES-specific Docker account.